### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
           cache: 'poetry'
       - name: Install Chirp and its dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install libsndfile1 ffmpeg
           poetry install
       - name: Test with unittest


### PR DESCRIPTION
It seems that the CI bot broke because the apt-get cache was out of date. Adding `sudo apt-get update` before trying to install the librosa dependencies seems to fix it.