### PR TITLE
Adding DUST method for SFDA.

### DIFF
--- a/chirp/projects/sfda/configs/config_globals.py
+++ b/chirp/projects/sfda/configs/config_globals.py
@@ -34,6 +34,7 @@ from chirp.projects.sfda.methods import pseudo_label
 from chirp.projects.sfda.methods import shot
 from chirp.projects.sfda.methods import nrc
 from chirp.projects.sfda.methods import tent
+from chirp.projects.sfda.methods import dust
 from flax import linen as nn
 
 
@@ -57,5 +58,6 @@ def get_globals() -> Dict[str, Any]:
       "shot": shot,
       "ada_bn": ada_bn,
       "dropout_student": dropout_student,
-      "nrc": nrc
+      "nrc": nrc,
+      "dust": dust
   }

--- a/chirp/projects/sfda/configs/dust.py
+++ b/chirp/projects/sfda/configs/dust.py
@@ -1,0 +1,79 @@
+# coding=utf-8
+# Copyright 2022 The Chirp Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Configuration file for the DUST SFDA method."""
+from chirp import config_utils
+from chirp.projects.sfda import model_utils
+from ml_collections import config_dict
+
+
+def get_image_config() -> config_dict.ConfigDict:  # pylint: disable=missing-function-docstring
+
+  # Configure adaptation
+  image_config = config_dict.ConfigDict()
+
+  optimizer_cfg = config_dict.ConfigDict()
+  optimizer_cfg.optimizer = "adam"
+  optimizer_cfg.opt_kwargs = {}
+  optimizer_cfg.weight_decay = 0.
+  optimizer_cfg.learning_rate = 1e-3
+  optimizer_cfg.use_cosine_decay = True
+  optimizer_cfg.trainable_params_strategy = model_utils.TrainableParams.BN
+  image_config.optimizer_config = optimizer_cfg
+
+  # Method-specifc hparam
+  image_config.num_random_passes = 3
+  image_config.kl_threshold = 0.9
+
+  # Forward options
+  image_config.num_epochs = 10
+  image_config.use_dropout = False
+  image_config.update_bn_statistics = True
+  return image_config
+
+
+def get_audio_config() -> config_dict.ConfigDict:  # pylint: disable=missing-function-docstring
+
+  # Configure adaptation
+  audio_config = config_dict.ConfigDict()
+
+  optimizer_cfg = config_dict.ConfigDict()
+  optimizer_cfg.optimizer = "adam"
+  optimizer_cfg.opt_kwargs = {}
+  optimizer_cfg.weight_decay = 0.
+  optimizer_cfg.learning_rate = 1e-5
+  optimizer_cfg.use_cosine_decay = False
+  optimizer_cfg.trainable_params_strategy = model_utils.TrainableParams.BN
+  audio_config.optimizer_config = optimizer_cfg
+
+  # Method-specifc hparam
+  audio_config.num_random_passes = 3
+  audio_config.kl_threshold = 0.9
+
+  # Forward options
+  audio_config.num_epochs = 10
+  audio_config.use_dropout = True
+  audio_config.update_bn_statistics = False
+  return audio_config
+
+
+def get_config() -> config_dict.ConfigDict:
+
+  method_config = config_dict.ConfigDict()
+  method_config.sfda_method = config_utils.callable_config(
+      "dust.DUST")
+  method_config.audio = get_audio_config()
+  method_config.image = get_image_config()
+  return method_config

--- a/chirp/projects/sfda/losses.py
+++ b/chirp/projects/sfda/losses.py
@@ -16,10 +16,58 @@
 """A set of common losses used by several SFDA methods."""
 
 from typing import Optional
-
+import enum
 import flax
 import jax
 import jax.numpy as jnp
+
+
+class ReduceStrategy(enum.Enum):
+  """Strategies to reduce an axis.
+
+  Attributes:
+      NONE: No reduction
+      AVERAGE: Average reduction
+  """
+  NONE = "none"
+  AVERAGE = "average"
+
+
+def label_kl(probabilities: jnp.ndarray,
+             label: jnp.ndarray,
+             eps: float = 1e-10,
+             **_) -> jnp.ndarray:
+  """Kulback-Leibler divergence for single-class classification settings.
+
+  Args:
+    probabilities: Model's probabilities, expected shape [*, num_classes].
+    label: One-hot labels, expected shape [*, num_classes].
+    eps: For numerical stability
+
+  Returns:
+    Single-class Kulback-Leibler divergence between probabilities and label.
+    Shape [*,].
+  """
+  return label_xent(probabilities, label) - label_ent(probabilities)
+
+
+def label_binary_kl(probabilities: jnp.ndarray,
+                    label: jnp.ndarray,
+                    eps: float = 1e-10,
+                    **_) -> jnp.ndarray:
+  """Kulback-Leibler divergence for multi-class classification settings.
+
+  Args:
+    probabilities: Model's probabilities, expected shape [*, num_classes].
+    label: One-hot labels, expected shape [*, num_classes].
+    eps: For numerical stability
+
+  Returns:
+    Multi-class Kulback-Leibler divergence between probabilities and label.
+    Shape [*, num_classes].
+  """
+  return (label_binary_xent(probabilities, label, class_reduce=ReduceStrategy.NONE) -
+          label_binary_ent(probabilities, class_reduce=ReduceStrategy.NONE))
 
 
 def label_xent(probabilities: jnp.ndarray,
@@ -63,6 +111,7 @@ def label_ent(probabilities: jnp.ndarray,
 def label_binary_ent(probabilities: jnp.ndarray,
                      label_mask: Optional[jnp.ndarray] = None,
                      eps: float = 1e-10,
+                     class_reduce: ReduceStrategy = ReduceStrategy.AVERAGE,
                      **_) -> jnp.ndarray:
   """Computes averaged classwise binary entropy.
 
@@ -75,6 +124,9 @@ def label_binary_ent(probabilities: jnp.ndarray,
 
   Returns:
     The binary entropies, averaged across classes shape [*,]
+
+  Raises:
+    ValueError: In case class_reduce is not a known ReduceStrategy.
   """
   if label_mask is None:
     label_mask = jnp.ones_like(probabilities)
@@ -82,15 +134,21 @@ def label_binary_ent(probabilities: jnp.ndarray,
                                                    label_mask.shape)
   binary_entropies = -(probabilities * jnp.log(probabilities + eps) +
                        (1 - probabilities) * jnp.log((1 - probabilities) + eps)
-                      )  # [..., num_classes]
-  return (label_mask * binary_entropies).sum(axis=-1) / (
-      label_mask.sum(axis=-1) + eps)
+                       )  # [..., num_classes]
+  if class_reduce == ReduceStrategy.AVERAGE:
+    return (label_mask * binary_entropies).sum(axis=-1) / (
+        label_mask.sum(axis=-1) + eps)
+  elif class_reduce == ReduceStrategy.NONE:
+    return (label_mask * binary_entropies)
+  else:
+    raise ValueError(f"Unknown reduce strategy {class_reduce} used.")
 
 
 def label_binary_xent(probabilities: jnp.ndarray,
                       label: jnp.ndarray,
                       label_mask: Optional[jnp.ndarray] = None,
                       eps: float = 1e-10,
+                      class_reduce: ReduceStrategy = ReduceStrategy.AVERAGE,
                       **_) -> jnp.ndarray:
   """Computes averaged classwise binary cross-entropy.
 
@@ -102,6 +160,9 @@ def label_binary_xent(probabilities: jnp.ndarray,
 
   Returns:
     Average of per-class binary xent. Shape [*]
+
+  Raises:
+    ValueError: In case class_reduce is not a known ReduceStrategy.
   """
   if label_mask is None:
     label_mask = jnp.ones_like(probabilities)
@@ -109,9 +170,14 @@ def label_binary_xent(probabilities: jnp.ndarray,
       probabilities.shape, label_mask.shape, label_mask.shape)
   binary_entropies = -(label * jnp.log(probabilities + eps) +
                        (1 - label) * jnp.log((1 - probabilities) + eps)
-                      )  # [..., num_classes]
-  return (label_mask * binary_entropies).sum(axis=-1) / (
-      label_mask.sum(axis=-1) + eps)
+                       )  # [..., num_classes]
+  if class_reduce == ReduceStrategy.AVERAGE:
+    return (label_mask * binary_entropies).sum(axis=-1) / (
+        label_mask.sum(axis=-1) + eps)
+  elif class_reduce == ReduceStrategy.NONE:
+    return (label_mask * binary_entropies)
+  else:
+    raise ValueError(f"Unknown reduce strategy {class_reduce} used.")
 
 
 def l2_loss(params: flax.core.scope.VariableDict):

--- a/chirp/projects/sfda/methods/dust.py
+++ b/chirp/projects/sfda/methods/dust.py
@@ -1,0 +1,167 @@
+# coding=utf-8
+# Copyright 2022 The Chirp Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Test-Time Entropy Minimization (TENT) method."""
+
+from typing import Dict, Tuple, Type
+from absl import logging
+import functools
+from chirp.projects.sfda import adapt
+from chirp.projects.sfda import losses
+from chirp.projects.sfda import method_utils
+from chirp.projects.sfda import model_utils
+from clu import metrics as clu_metrics
+import flax.jax_utils as flax_utils
+import flax.linen as nn
+import jax
+import jax.numpy as jnp
+import numpy as np
+import tensorflow as tf
+
+
+class DUST(adapt.SFDAMethod):
+  """Adaptation of Dropout-based Uncertainty-driven Self-Training for SFDA."""
+
+  _CITATION = ("Khurana, Sameer, et al. 'Unsupervised domain adaptation for"
+  "speech recognition via uncertainty driven self-training.' ICASSP 2021-2021 "
+  "IEEE International Conference on Acoustics, Speech and Signal Processing"
+  "(ICASSP). IEEE, 2021.")
+
+  def before_epoch(self, key: jax.random.PRNGKeyArray,
+                   model_bundle: model_utils.ModelBundle,
+                   adaptation_state: adapt.AdaptationState,
+                   adaptation_dataset: tf.data.Dataset,
+                   modality: adapt.Modality, multi_label: bool,
+                   **method_kwargs) -> adapt.AdaptationState:
+    """Compute the pseudo-labels, the masks and store them in memory.
+
+    Args:
+      key: The jax random key used for random operations in this epoch.
+      model_bundle: The ModelBundle used for adaptation.
+      adaptation_state: The current state of adaptation.
+      adaptation_dataset: The dataset used for adaptation.
+      modality: The current modality.
+      multi_label: Whether this is a multi-label problem.
+      **method_kwargs: Additional method-specific kwargs.
+
+    Returns:
+      The adaptation state, with a potentially updated 'method_state' attribute.
+    """
+    logging.info("Preparing pseudo-labels...")
+    forward_fn = functools.partial(
+        method_utils.forward_dataset, dataset=adaptation_dataset,
+        adaptation_state=adaptation_state,
+        model_bundle=model_bundle,
+        modality=modality,
+        multi_label=multi_label,
+        use_batch_statistics=method_kwargs["update_bn_statistics"],
+        only_keep_unmasked_classes=False)
+
+    # Compute model's reference predictions (no dropout used)
+    reference_forward_result = forward_fn(train=False)
+    reference_probability = reference_forward_result['proba']
+
+    # We perform multiple noisy forward passes, and keep track of the
+    # KL-divergence between the reference predictions and noisy predictions.
+    kl_distances = []
+    kl_fn = losses.label_binary_kl if multi_label else losses.label_kl
+    for random_pass in range(method_kwargs["num_random_passes"]):
+      random_pass_key, key = jax.random.split(key)
+      noisy_probability = forward_fn(key=random_pass_key, train=True)['proba']
+      kl_distances.append(kl_fn(reference_probability, noisy_probability))
+
+    # We compute the mask by only keeping samples who maximum kl_divergence
+    # observed is lower than a pre-defined threshold.
+    pseudo_label_mask = jnp.stack(kl_distances, 0).max(
+        axis=0) < method_kwargs["kl_threshold"]
+    sample_ids = reference_forward_result["id"]
+    pseudo_label = reference_probability
+
+    # method_state will act as a memory, from which pseudo-labels and masks
+    # will be grabbed on-the-go over the next epoch of adaptation.
+
+    method_state = {
+        "pseudo_label": pseudo_label,
+        "pseudo_label_mask": pseudo_label_mask,
+        "id2index": {sample_ids[i]: i for i in range(len(sample_ids))},
+    }
+    adaptation_state = adaptation_state.replace(method_state=method_state)
+    return adaptation_state
+
+  def before_iter(
+          self, key: jax.random.PRNGKeyArray, batch: Dict[str, np.ndarray],
+          adaptation_state: adapt.AdaptationState,
+          model_bundle: model_utils.ModelBundle, modality: adapt.Modality,
+          multi_label: bool,
+          **method_kwargs) -> Tuple[adapt.AdaptationState, Dict[str, jnp.ndarray]]:
+    """Grab the pseudo-labels and masks for the current batch.
+
+    Args:
+      key: The jax random key used for random operations.
+      batch: The current batch of data.
+      adaptation_state: The current state of adaptation.
+      model_bundle: The ModelBundle used for adaptation.
+      modality: The current modality.
+      multi_label: Whether this is a multi-label problem.
+      **method_kwargs: Additional method-specific kwarg
+
+    Returns:
+      A dictionary containing the pseudo-labels and mask to use for the iteration.
+    """
+    method_state = flax_utils.unreplicate(adaptation_state.method_state)
+    id2index = method_state["id2index"]
+    batch_indices = np.array(
+        [id2index[x] for x in flax_utils.unreplicate(batch["tfds_id"])])
+    pseudo_label = method_state["pseudo_label"][batch_indices]
+    pseudo_label_mask = method_state["pseudo_label_mask"][batch_indices]
+    return adaptation_state, {
+        "pseudo_label": flax_utils.replicate(pseudo_label),
+        "pseudo_label_mask": flax_utils.replicate(pseudo_label_mask)
+    }
+
+  def get_adaptation_metrics(self, supervised: bool, multi_label: bool,
+                             **method_kwargs) -> Type[clu_metrics.Collection]:
+    """Obtain metrics that will be monitored during adaptation."""
+    metrics_dict = vars(
+        adapt.get_common_metrics(
+            supervised=supervised, multi_label=multi_label))["__annotations__"]
+
+    def single_label_loss_fn(probabilities, pseudo_label, pseudo_label_mask,
+                             **_):
+      pl_xent = losses.label_xent(
+          probabilities=probabilities,
+          label=pseudo_label,
+          sample_mask=pseudo_label_mask)
+      return pl_xent
+
+    def multi_label_loss_fn(probabilities: jnp.ndarray,
+                            pseudo_label: jnp.ndarray,
+                            pseudo_label_mask: jnp.ndarray,
+                            label_mask: jnp.ndarray, **_):
+
+      # Sample's probabilities that end up contributing to the final computation
+      # are those left unmasked by label_mask (defined by the target domain and
+      # restricting the set of possible species) and are confident enough (
+      # left unmasked by pseudo_label_mask).
+      pl_xent = losses.label_binary_xent(
+          probabilities=probabilities,
+          label=pseudo_label,
+          label_mask=label_mask * pseudo_label_mask,
+      )
+      return pl_xent
+
+    loss_fn = multi_label_loss_fn if multi_label else single_label_loss_fn
+    metrics_dict["main_loss"] = clu_metrics.Average.from_fun(loss_fn)
+    return clu_metrics.Collection.create(**metrics_dict)

--- a/chirp/projects/sfda/tests/sfda_test.py
+++ b/chirp/projects/sfda/tests/sfda_test.py
@@ -35,6 +35,7 @@ from chirp.projects.sfda.configs import pseudo_label as pseudo_label_config
 from chirp.projects.sfda.configs import nrc as nrc_config
 from chirp.projects.sfda.configs import shot as shot_config
 from chirp.projects.sfda.configs import tent as tent_config
+from chirp.projects.sfda.configs import dust as dust_config
 from chirp.projects.sfda.tests import fake_image_dataset
 from chirp.tests import fake_dataset
 from flax import traverse_util
@@ -52,6 +53,7 @@ _UNPARSED_CONFIGS = {
     "ada_bn": ada_bn_config,
     "dropout_student": ds_config,
     "nrc": nrc_config,
+    "dust": dust_config
 }
 
 
@@ -158,7 +160,7 @@ class AdaptationTest(parameterized.TestCase):
       (f"{method}_{modality.value}", method, modality)
       for method, modality in itertools.product([
           "dropout_student", "ada_bn", "tent", "notela", "pseudo_label", "shot",
-          "nrc"
+          "nrc", "dust"
       ], [adapt.Modality.IMAGE, adapt.Modality.AUDIO])
   ])
   def test_adapt_one_epoch(self, method: str, modality: adapt.Modality):


### PR DESCRIPTION
Adaptation of DUST. Initially, the method was designed for standard UDA) and applied to Automatic Speech Recognition. Therefore,  I summarize the design choices made here:

- Instead of the "edit distance" (which to my understanding is made for string predictions", I'm using the KL divergence (between soft predictions of the model). That means that we're using a kl_threshold (for which the appropriate value will need to be found, my default having absolutely no particular meaning).
- Using the clean (soft) predictions of the model as pseudo-labels instead of hard pseudo-labels (soft works usually ok by default, hard would require introducing an additional confidence threshold).
- The original method performs a full re-training before re-selecting the new set of pseudo-labeled samples. Instead, I'm doing it on a per-epoch basis (before each epoch, we re-do the pseudo-labeling part).
