### PR TITLE
Starting to extend SFDA pipeline to support single-label classification for audio.

### DIFF
--- a/chirp/data/pipeline.py
+++ b/chirp/data/pipeline.py
@@ -875,7 +875,7 @@ class FilterMultiLabelRecordings(DatasetPreprocessOp):
       self, dataset: tf.data.Dataset, dataset_info: tfds.core.DatasetInfo
   ) -> tf.data.Dataset:
     def _predicate(features):
-      return len(features['label']) == 1
+      return tf.math.equal(tf.shape(features['label'])[0], 1)
     return dataset.filter(_predicate)
 
 @dataclasses.dataclass

--- a/chirp/data/pipeline.py
+++ b/chirp/data/pipeline.py
@@ -866,7 +866,17 @@ class OnlyKeep(FeaturesPreprocessOp):
         for name, feature in features.items()
         if name in self.names
     }
+  
+@dataclasses.dataclass
+class FilterMultiLabelRecordings(DatasetPreprocessOp):
+  """Filters out recordings that have multiple foreground labels."""
 
+  def __call__(
+      self, dataset: tf.data.Dataset, dataset_info: tfds.core.DatasetInfo
+  ) -> tf.data.Dataset:
+    def _predicate(features):
+      return len(features['label']) == 1
+    return dataset.filter(_predicate)
 
 @dataclasses.dataclass
 class FilterByFeature(DatasetPreprocessOp):

--- a/chirp/projects/sfda/adapt.py
+++ b/chirp/projects/sfda/adapt.py
@@ -420,17 +420,13 @@ class SFDAMethod(metaclass=abc.ABCMeta):
         )
 
       # Compute metrics and loss
-      logits2probas = nn.sigmoid if multi_label else nn.softmax
+      label_mask = batch.get("label_mask", None)
       gather_args = {
           "multi_label": multi_label,
           "outputs": model_outputs,
-          "probabilities": logits2probas(model_outputs.label),
-          "label_mask": (
-              jnp.ones_like(model_outputs.label)
-              if "label_mask" not in batch
-              else batch["label_mask"]
-          ),
-      }
+          "probabilities": logit2proba(
+              model_outputs.label, label_mask, multi_label),
+          "label_mask": label_mask}
       gather_args.update(method_gather_args)
       if use_supervised_metrics:
         gather_args.update({"label": batch["label"].astype(np.int32)})
@@ -513,8 +509,7 @@ class SFDAMethod(metaclass=abc.ABCMeta):
     # Iterate over batches.
     adaptation_state = flax_utils.replicate(adaptation_state)
     for batch in tqdm.tqdm(
-        adaptation_dataset.as_numpy_iterator(), total=len(adaptation_dataset)
-    ):
+        adaptation_dataset.as_numpy_iterator()):
       batch = jax.tree_map(np.asarray, batch)
       verify_batch(batch)
       current_step = int(flax_utils.unreplicate(adaptation_state.step))
@@ -610,15 +605,14 @@ class SFDAMethod(metaclass=abc.ABCMeta):
           train=False,
           use_running_average=True,
       )
-      logits2probas = nn.sigmoid if multi_label else nn.softmax
+      label_mask = batch.get("label_mask", None)
       return model_outputs, metric_collection.merge(
           metric_collection.gather_from_model_output(
               multi_label=multi_label,
               outputs=model_outputs,
-              probabilities=logits2probas(model_outputs.label),
-              label_mask=jnp.ones_like(model_outputs.label)
-              if "label_mask" not in batch
-              else batch["label_mask"],
+              probabilities=logit2proba(
+                  model_outputs.label, label_mask, multi_label),
+              label_mask=label_mask,
               label=batch["label"].astype(np.int32),
           )
       )
@@ -811,6 +805,27 @@ def perform_adaptation(
   validation_writer.close()
   return adaptation_state
 
+def logit2proba(logits: jnp.ndarray,
+                label_mask: jnp.ndarray | None,
+                multi_label: bool) -> jnp.array:
+    """Converts model logits to valid probabilities.
+    
+    When multi_label=False, uses label_mask to select classes that will be used
+    in the softmax normalization term. The output probabilities should
+    verify jnp.all(probabilities[..., label_mask].sum(-1) == 1.0).
+
+    Args:
+      logits: The logits to be transformed, shape [*, num_classes]
+      label_mask: The mask conveying the classes to be used.
+        Shape [*, num_classes]
+      multi_label: Whether we're in the multi-label setting or not.
+
+    Returns:
+      The resulting probabilities, shape [*, num_classes]
+    """
+    fn = nn.sigmoid if multi_label else functools.partial(
+          nn.softmax, where=label_mask, initial=0)
+    return fn(logits)
 
 def keyed_map(
     key: str, outputs: output.AnyOutput, **kwargs

--- a/chirp/projects/sfda/losses.py
+++ b/chirp/projects/sfda/losses.py
@@ -36,20 +36,25 @@ class ReduceStrategy(enum.Enum):
 
 
 def label_kl(
-    probabilities: jnp.ndarray, label: jnp.ndarray, eps: float = 1e-10, **_
-) -> jnp.ndarray:
+    probabilities: jnp.ndarray,
+    label: jnp.ndarray,
+    label_mask: jnp.ndarray | None,
+    eps: float = 1e-10, **_) -> jnp.ndarray:
   """Kulback-Leibler divergence for single-class classification settings.
 
   Args:
     probabilities: Model's probabilities, expected shape [*, num_classes].
     label: One-hot labels, expected shape [*, num_classes].
+    label_mask: Array representing classes to be kept, shape [*, num_classes].
     eps: For numerical stability
 
   Returns:
     Single-class Kulback-Leibler divergence between probabilities and label.
     Shape [*,].
   """
-  return label_xent(probabilities, label, eps) - label_ent(probabilities, eps)  # pytype: disable=wrong-arg-types  # jax-ndarray
+  return label_xent(
+      probabilities, label, label_mask, eps) - label_ent(
+      probabilities, label_mask, eps)  # pytype: disable=wrong-arg-types  # jax-ndarray
 
 
 def label_binary_kl(
@@ -73,6 +78,7 @@ def label_binary_kl(
 def label_xent(
     probabilities: jnp.ndarray,
     label: jnp.ndarray,
+    label_mask: jnp.ndarray | None,
     sample_mask: jnp.ndarray | None = None,
     eps: float = 1e-10,
     **_,
@@ -82,6 +88,8 @@ def label_xent(
   Args:
     probabilities: Model's probabilities, expected shape [*, num_classes].
     label: One-hot labels, expected shape [*, num_classes].
+    label_mask: label_mask: Array representing classes to be kept,
+      shape [*, num_classes].
     sample_mask: A way to mask out some samples when computing the loss. Useful
       for instance to only keep high-confidence samples in pseudo-labelling.
     eps: For numerical stability
@@ -91,24 +99,40 @@ def label_xent(
   """
   if sample_mask is None:
     sample_mask = jnp.ones(probabilities.shape[:-1])
-  xent = -(label * jnp.log(probabilities + eps)).sum(-1)
+  if label_mask is not None and (
+          label_mask.shape[-1] == probabilities.shape[-1]):
+    xent = -((label * jnp.log(probabilities + eps)) * label_mask).sum(-1)
+  else:
+    # TODO(mboudiaf) If label_mask is not None, check that probabilities are
+    # already masked. In other words, ensure
+    # probabilities.shape[-1] == label_mask.sum(-1)
+    xent = -(label * jnp.log(probabilities + eps)).sum(-1)
   return sample_mask * xent
 
 
-def label_ent(
-    probabilities: jnp.ndarray, eps: float = 1e-10, **_
-) -> jnp.ndarray:
+def label_ent(probabilities: jnp.ndarray,
+              label_mask: jnp.ndarray | None,
+              eps: float = 1e-10,
+              **_) -> jnp.ndarray:
   """Standard entropy used for single-label classification settings.
 
   Args:
     probabilities: Model's probabilities, expected shape [*, num_classes]
+    label_mask: label_mask: Array representing classes to be kept,
+      shape [*, num_classes].
     eps: For numerical stability.
 
   Returns:
     The entropy of probabilities, shape [*,]
   """
-  return -(probabilities * jnp.log(probabilities + eps)).sum(-1)
-
+  if label_mask is not None and label_mask.shape[-1] == probabilities.shape[-1]:
+    ent = -((probabilities * jnp.log(probabilities + eps)) * label_mask).sum(-1)
+  else:
+    # TODO(mboudiaf) If label_mask is not None, check that probabilities are
+    # already masked. In other words, ensure
+    # probabilities.shape[-1] == label_mask.sum(-1)
+    ent = -((probabilities * jnp.log(probabilities + eps))).sum(-1)
+  return ent
 
 def label_binary_ent(
     probabilities: jnp.ndarray,

--- a/chirp/projects/sfda/metrics.py
+++ b/chirp/projects/sfda/metrics.py
@@ -32,7 +32,7 @@ class Accuracy(clu_metrics.Average):
 
   @classmethod
   def from_model_output(
-      cls, probabilities: jnp.array, label: jnp.array, **kwargs
+      cls, probabilities: jnp.ndarray, label: jnp.ndarray, **kwargs
   ) -> clu_metrics.Metric:
     return super().from_model_output(
         values=(probabilities.argmax(axis=-1) == label.argmax(axis=-1)).astype(
@@ -52,18 +52,21 @@ class MarginalEntropy(clu_metrics.Metric):
   non-`averageable` metric, which is why we dedicate a separate metric for it.
   """
 
-  probability_sum: jnp.array
+  probability_sum: jnp.ndarray
   n_samples: int
   multi_label: bool
+  label_mask: jnp.ndarray | None
 
   @classmethod
   def from_model_output(
-      cls, probabilities: jnp.array, multi_label: bool, **_
+      cls, probabilities: jnp.ndarray, multi_label: bool, label_mask: jnp.ndarray,
+      **_
   ) -> "MarginalEntropy":
     return cls(
         probability_sum=probabilities.sum(axis=0),
         n_samples=probabilities.shape[0],
         multi_label=multi_label,
+        label_mask=label_mask
     )
 
   def merge(self, other: "MarginalEntropy") -> "MarginalEntropy":
@@ -71,15 +74,18 @@ class MarginalEntropy(clu_metrics.Metric):
         probability_sum=self.probability_sum + other.probability_sum,
         n_samples=self.n_samples + other.n_samples,
         multi_label=other.multi_label,
+        label_mask=other.label_mask
     )
 
   def compute(self):
     proba_marginal = self.probability_sum * (1 / self.n_samples)
-    return losses.label_ent(proba_marginal)
+    reference_mask = None if self.label_mask is None else self.label_mask[0]
+    return losses.label_ent(proba_marginal, reference_mask)
 
   @classmethod
   def empty(cls) -> "MarginalEntropy":
-    return cls(probability_sum=0.0, n_samples=0, multi_label=False)
+    return cls(probability_sum=0.0, n_samples=0, multi_label=False,
+               label_mask=None)
 
 
 @flax.struct.dataclass
@@ -90,16 +96,16 @@ class MarginalBinaryEntropy(clu_metrics.Metric):
   multi_label.
   """
 
-  probability_sum: jnp.array
+  probability_sum: jnp.ndarray
   n_samples: int
-  label_mask: jnp.array
+  label_mask: jnp.ndarray
   multi_label: bool
 
   @classmethod
   def from_model_output(
       cls,
       label_mask: jnp.ndarray,
-      probabilities: jnp.array,
+      probabilities: jnp.ndarray,
       multi_label: bool,
       **_
   ) -> "MarginalBinaryEntropy":

--- a/chirp/projects/sfda/tests/losses_test.py
+++ b/chirp/projects/sfda/tests/losses_test.py
@@ -61,7 +61,7 @@ class LossesTest(absltest.TestCase):
     n_points = 10
     logits = jax.random.uniform(jax.random.PRNGKey(0), (n_points, num_classes))
     probabilities = nn.softmax(logits)
-    ent = losses.label_ent(probabilities)
+    ent = losses.label_ent(probabilities=probabilities, label_mask=None)
 
     # Test that multi-class entropies fall in the range [0, log(num_classes)]
     self.assertTrue((ent >= 0.0).all())
@@ -71,7 +71,7 @@ class LossesTest(absltest.TestCase):
     self.assertAlmostEqual(
         ent.mean(),
         losses.label_xent(
-            probabilities=probabilities, label=probabilities
+            probabilities=probabilities, label=probabilities, label_mask=None,
         ).mean(),
     )
 


### PR DESCRIPTION
First commits to start the extension. With the current modifications, we should be able to run TENT on actual audio datasets with multi_label=False. Once this is validated, I'll push the changes for each remaining method.